### PR TITLE
HOTFIX: Fix GitHub tag naming syntax

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          TAG_NAME: "v0.0.${{ github.run_number }} prod"
+          TAG_NAME: "v0.0.${{ github.run_number }}-prod"
           RELEASE_NAME: "Build v0.0.${{ github.run_number }} prod"
         with:
           tag_name: ${{ env.TAG_NAME }}


### PR DESCRIPTION
Replace " " with "-" in GitHub release tag in-between the build number and the build environment